### PR TITLE
Clarify about Settings file

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ Does not reliably handle situations where you have multiple instances of the sam
 
 ### Run the Pre-Built Binary
 
-In the Releases section in the right-hand sidebar, click Version 1.2 and from 
-there download TANWindowMgr.exe.
+1. In the Releases section in the right-hand sidebar, click Version 1.2 and from 
+   there download TANWindowMgr.exe.
+2. If you run the software from folder X, the Settings.ini will be created 
+   there. If you move the .exe file, move the Settings.ini file with it.
 
 ### Build it Yourself
 
@@ -32,6 +34,7 @@ there download TANWindowMgr.exe.
 4. Build | Build Solution or Ctrl+Shift+B
 5. The .exe file will be created in the folder
    TANWindowMgr\TANWindowMgr\bin\Debug\TANWindowMgr.exe
+6. Run as described in the prior section.
 
 ## Author
 Todd Nelson  


### PR DESCRIPTION
I had copied TANWindowMgr.exe to my desktop, but I forgot about the Settings file which was still in my Downloads folder, from where I initially had run the .exe when first starting to test it. After a reboot, TANWIndowMgr could not find any saved settings. For a moment I thought I lost all my setup work! Nope--settings were still where they were initially...I thought a quick note in the docs would help someone in the future.